### PR TITLE
fix(INT-98): Support multi-value attributes (arrays)

### DIFF
--- a/integration.js
+++ b/integration.js
@@ -321,6 +321,8 @@ function parseAttributeValue(value) {
       value: moment(value / 1e4 - 1.16444736e13).toISOString(),
       type: 'date'
     };
+  } else if (Array.isArray(value)) {
+    return { value, type: 'array' };
   } else {
     return { value, type: 'string' };
   }

--- a/styles/ldap.less
+++ b/styles/ldap.less
@@ -2,10 +2,13 @@ div.group-container {
   margin-bottom: 10px;
 }
 
-.array-item:after {
-  content: ', ';
-}
-
-.array-item:last-child::after {
+.array-item {
+  font-weight: bold;
+  &:after {
+    content: ', ';
+  }
+  &:last-child::after {
   content: "";
+
+  }
 }

--- a/styles/ldap.less
+++ b/styles/ldap.less
@@ -1,3 +1,11 @@
-div.group-container{
+div.group-container {
   margin-bottom: 10px;
+}
+
+.array-item:after {
+  content: ', ';
+}
+
+.array-item:last-child::after {
+  content: "";
 }

--- a/styles/ldap.less
+++ b/styles/ldap.less
@@ -5,10 +5,9 @@ div.group-container {
 .array-item {
   font-weight: bold;
   &:after {
-    content: ', ';
+    content: ", ";
   }
   &:last-child::after {
-  content: "";
-
+    content: "";
   }
 }

--- a/templates/ldap-block.hbs
+++ b/templates/ldap-block.hbs
@@ -6,6 +6,11 @@
         <span class="p-key">{{attribute.display}}: </span>
         {{#if (eq attribute.type 'date')}}
             <span class="p-value">{{moment-format attribute.value 'L LTS' timeZone=timezone}}</span>
+        {{else if (eq attribute.type 'array')}}
+            {{humanize (dasherize attribute.display)}}:
+            {{#each attribute.value as | value |}}
+                    <span class="array-item">{{value}}</span>
+            {{/each}}
         {{else}}
             <span class="p-value">{{attribute.value}}</span>
         {{/if}}

--- a/templates/ldap-block.hbs
+++ b/templates/ldap-block.hbs
@@ -3,16 +3,18 @@
 </h1>
 {{#each details.userDetailsList as |attribute|}}
     <div>
-        <span class="p-key">{{attribute.display}}: </span>
-        {{#if (eq attribute.type 'date')}}
-            <span class="p-value">{{moment-format attribute.value 'L LTS' timeZone=timezone}}</span>
-        {{else if (eq attribute.type 'array')}}
-            {{humanize (dasherize attribute.display)}}:
+        {{#if (eq attribute.type 'array')}}
+            {{titleize (humanize (dasherize attribute.display))}}:
             {{#each attribute.value as | value |}}
-                    <span class="array-item">{{value}}</span>
+                <span class="array-item">{{value}}</span>
             {{/each}}
         {{else}}
-            <span class="p-value">{{attribute.value}}</span>
+            <span class="p-key">{{attribute.display}}: </span>
+            {{#if (eq attribute.type 'date')}}
+                <span class="p-value">{{moment-format attribute.value 'L LTS' timeZone=timezone}}</span>
+            {{else}}
+                <span class="p-value">{{attribute.value}}</span>
+            {{/if}}
         {{/if}}
     </div>
 {{/each}}

--- a/templates/ldap-summary.hbs
+++ b/templates/ldap-summary.hbs
@@ -4,6 +4,11 @@
         <span class="integration-text-color">
             {{#if (eq attribute.type 'date')}}
                 {{humanize (dasherize attribute.display)}}: {{moment-format attribute.value 'L LTS' timeZone=timezone}}
+            {{else if (eq attribute.type 'array')}}
+                {{humanize (dasherize attribute.display)}}:
+                {{#each attribute.value as | value |}}
+                    <span class="array-item">{{value}}</span>
+                {{/each}}
             {{else}}
                 {{humanize (dasherize attribute.display)}}: {{attribute.value}}
             {{/if}}


### PR DESCRIPTION
@penwoodjon Was testing out multi-value attributes on our AD test server and realized how simple the fix is to support them.  Starting in Web `3.6.6` arrays will be handled out of the box by Ember but we explicitly handle them now which lets us do more advanced formatting if needed.  For now I just display the array values as a comma delimited list.